### PR TITLE
Pass kwargs to initial_sample

### DIFF
--- a/src/abstractmcmc.jl
+++ b/src/abstractmcmc.jl
@@ -22,7 +22,7 @@ function AbstractMCMC.step(
     rng::Random.AbstractRNG, model::AbstractMCMC.AbstractModel, ::ESS; kwargs...
 )
     # initial sample from the Gaussian prior
-    f = initial_sample(rng, model)
+    f = initial_sample(rng, model; kwargs...)
 
     # compute log-likelihood of the initial sample
     loglikelihood = Distributions.loglikelihood(model, f)


### PR DESCRIPTION
The idea behing this PR is to allow different behavior for `initial_sample` by passing the `kwargs` as well. Typically passing a defined starting point for the MCMC chain.