### PR TITLE
Use more lightweight ArrayInterfaceCore, drop Julia < 1.6, and release ESS 1.0.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,18 @@
 name = "EllipticalSliceSampling"
 uuid = "cad2338a-1db2-11e9-3401-43bc07c9ede2"
 authors = ["David Widmann <david.widmann@it.uu.se>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
-ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 AbstractMCMC = "3.2, 4"
-ArrayInterface = "2, 3, 4, 5"
+ArrayInterfaceCore = "0.1"
 Distributions = "0.22, 0.23, 0.24, 0.25"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EllipticalSliceSampling"
 uuid = "cad2338a-1db2-11e9-3401-43bc07c9ede2"
 authors = ["David Widmann <david.widmann@it.uu.se>"]
-version = "0.5.1"
+version = "1.0.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
@@ -14,7 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 AbstractMCMC = "3.2, 4"
 ArrayInterfaceCore = "0.1"
 Distributions = "0.22, 0.23, 0.24, 0.25"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/EllipticalSliceSampling.jl
+++ b/src/EllipticalSliceSampling.jl
@@ -1,7 +1,7 @@
 module EllipticalSliceSampling
 
 using AbstractMCMC: AbstractMCMC
-using ArrayInterface: ArrayInterface
+using ArrayInterfaceCore: ArrayInterfaceCore
 using Distributions: Distributions
 
 using Random: Random

--- a/src/abstractmcmc.jl
+++ b/src/abstractmcmc.jl
@@ -13,7 +13,7 @@ end
 
 function ESSState(sample, loglikelihood)
     # create cache since it was not provided (initial sampling step)
-    cache = ArrayInterface.ismutable(sample) ? similar(sample) : nothing
+    cache = ArrayInterfaceCore.ismutable(sample) ? similar(sample) : nothing
     return ESSState(sample, loglikelihood, cache)
 end
 
@@ -83,7 +83,7 @@ function AbstractMCMC.step(
         θ = θmin + rand(rng) * (θmax - θmin)
 
         # recompute the proposal
-        if ArrayInterface.ismutable(fnext)
+        if ArrayInterfaceCore.ismutable(fnext)
             proposal!(fnext, prior, f, ν, θ)
         else
             fnext = proposal(prior, f, ν, θ)


### PR DESCRIPTION
With Julia 1.8 beta3 the following improvement can be observed:

## Latest release

```julia
julia> @time_imports using EllipticalSliceSampling
     26.9 ms    ┌ MacroTools
     45.5 ms  ┌ ZygoteRules
     23.8 ms          ┌ Preferences
     24.6 ms        ┌ JLLWrappers
     30.7 ms      ┌ Rmath_jll
    121.2 ms    ┌ Rmath
      4.1 ms    ┌ Compat
      0.5 ms    ┌ NaNMath
      2.7 ms    ┌ Calculus
     70.6 ms        ┌ ChainRulesCore
     71.8 ms      ┌ ChangesOfVariables
      1.1 ms      ┌ OpenLibm_jll
      1.9 ms      ┌ InverseFunctions
      5.4 ms      ┌ DocStringExtensions
      5.2 ms      ┌ IrrationalConstants
      0.7 ms      ┌ CompilerSupportLibraries_jll
      1.4 ms        ┌ LogExpFunctions
      0.9 ms        ┌ OpenSpecFun_jll
     18.7 ms      ┌ SpecialFunctions
     16.5 ms      ┌ DualNumbers
    123.9 ms    ┌ HypergeometricFunctions
      0.3 ms    ┌ Reexport
    264.0 ms  ┌ StatsFuns
      0.4 ms  ┌ DefineSingletons
      0.2 ms    ┌ IteratorInterfaceExtensions
      0.6 ms  ┌ TableTraits
      8.1 ms    ┌ OrderedCollections
      0.5 ms    ┌ Requires
      0.2 ms    ┌ DataValueInterfaces
      1.5 ms      ┌ DataAPI
     15.6 ms    ┌ Tables
      1.2 ms    ┌ ConstructionBase
     31.2 ms    ┌ Setfield
     31.0 ms    ┌ InitialValues
    136.5 ms  ┌ BangBang
     72.8 ms  ┌ DataStructures
    171.5 ms  ┌ FillArrays
      0.6 ms    ┌ StatsAPI
      0.8 ms    ┌ SortingAlgorithms
      9.9 ms    ┌ Missings
     37.3 ms  ┌ StatsBase
     10.7 ms    ┌ MicroCollections
      0.7 ms    ┌ Adapt
      0.5 ms    ┌ ArgCheck
     10.6 ms    ┌ SplittablesBase
      0.3 ms    ┌ CompositionsBase
     30.2 ms    ┌ Baselet
    117.6 ms  ┌ Transducers
     25.0 ms  ┌ PDMats
      8.5 ms    ┌ AbstractTrees
      4.0 ms    ┌ ProgressLogging
      7.2 ms    ┌ LeftChildRightSiblingTrees
     21.6 ms  ┌ TerminalLoggers
      1.6 ms    ┌ DensityInterface
      4.0 ms    ┌ QuadGK
    224.6 ms  ┌ Distributions
      0.3 ms  ┌ IfElse
     47.3 ms    ┌ Static
    589.7 ms  ┌ ArrayInterface
      7.4 ms  ┌ ProgressMeter
      3.0 ms  ┌ LoggingExtras
      1.1 ms  ┌ ConsoleProgressMonitor
      5.5 ms  ┌ AbstractMCMC
   1735.4 ms  EllipticalSliceSampling
```

## This PR

```julia
julia> @time_imports using EllipticalSliceSampling
     26.7 ms    ┌ MacroTools
     45.3 ms  ┌ ZygoteRules
     27.3 ms          ┌ Preferences
     28.2 ms        ┌ JLLWrappers
     33.1 ms      ┌ Rmath_jll
    119.6 ms    ┌ Rmath
      3.0 ms    ┌ Compat
      0.6 ms    ┌ NaNMath
      2.7 ms    ┌ Calculus
     71.7 ms        ┌ ChainRulesCore
     73.0 ms      ┌ ChangesOfVariables
      0.6 ms      ┌ OpenLibm_jll
      1.2 ms      ┌ InverseFunctions
      4.1 ms      ┌ DocStringExtensions
      5.7 ms      ┌ IrrationalConstants
      0.7 ms      ┌ CompilerSupportLibraries_jll
      1.3 ms        ┌ LogExpFunctions
      0.9 ms        ┌ OpenSpecFun_jll
     17.4 ms      ┌ SpecialFunctions
     15.9 ms      ┌ DualNumbers
    120.9 ms    ┌ HypergeometricFunctions
      0.3 ms    ┌ Reexport
    257.0 ms  ┌ StatsFuns
      0.3 ms  ┌ DefineSingletons
      0.2 ms    ┌ IteratorInterfaceExtensions
      0.5 ms  ┌ TableTraits
      8.2 ms    ┌ OrderedCollections
      0.6 ms    ┌ Requires
      0.2 ms    ┌ DataValueInterfaces
      1.2 ms      ┌ DataAPI
     15.3 ms    ┌ Tables
      1.1 ms    ┌ ConstructionBase
     31.0 ms    ┌ Setfield
     30.0 ms    ┌ InitialValues
    134.9 ms  ┌ BangBang
     72.1 ms  ┌ DataStructures
    170.9 ms  ┌ FillArrays
      0.6 ms    ┌ StatsAPI
      0.9 ms    ┌ SortingAlgorithms
      9.9 ms    ┌ Missings
     36.7 ms  ┌ StatsBase
     10.9 ms    ┌ MicroCollections
      0.7 ms    ┌ Adapt
      0.6 ms    ┌ ArgCheck
     10.8 ms    ┌ SplittablesBase
      0.3 ms    ┌ CompositionsBase
     29.6 ms    ┌ Baselet
    116.9 ms  ┌ Transducers
     24.7 ms  ┌ PDMats
      8.4 ms    ┌ AbstractTrees
      4.1 ms    ┌ ProgressLogging
      7.4 ms    ┌ LeftChildRightSiblingTrees
     21.7 ms  ┌ TerminalLoggers
      1.6 ms    ┌ DensityInterface
      3.6 ms    ┌ QuadGK
    223.8 ms  ┌ Distributions
      7.0 ms  ┌ ProgressMeter
      3.1 ms  ┌ LoggingExtras
      1.5 ms  ┌ ArrayInterfaceCore
      1.0 ms  ┌ ConsoleProgressMonitor
      5.7 ms  ┌ AbstractMCMC
   1128.4 ms  EllipticalSliceSampling
```

Since ArrayInterfaceCore only supports Julia >= 1.6, support for older Julia versions is removed. To be able to backport fixes and to follow the Julia Registry docs, hence a breaking new release is required. Since the package has been quite stable for some time, I guess it could be a good opportunity to release 1.0.0. In most cases it shouldn't make a difference whether we release 0.6 or 1 but with 1.0.0 we will be able to distinguish between feature and bugfix releases and can remove support for older Julia versions in a new (non-breaking) minor release instead.